### PR TITLE
Fix: Correct Mermaid diagram syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ graph TD
         M -- Tags & Hierarchy --> L;
 
         N[2. User Feedback] --> O(expert_review_tool.py);
-        P[3. Automated Discovery] --> O;
+        P[Automated Discovery] --> O;
         O -- Approved Knowledge --> K;
         I -- User Feedback --> N;
         F -- Knowledge Gap --> P;


### PR DESCRIPTION
The node text 'P[3. Automated Discovery]' caused a parsing error. I removed '3.' from the node text to resolve the error.