### PR TITLE
Refactor: Convert ingestion scripts to async/await with concurrency c…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY_HERE"
 # "gemini-1.5-flash-latest" is a powerful and cost-effective choice.
 LLM_MODEL="gemini-1.5-flash-latest"
 
+# Maximum number of simultaneous calls to the Gemini API during ingestion
+# This helps manage API rate limits and system load.
+MAX_CONCURRENT_GEMINI_CALLS=5
+
 
 # --- Neo4j Graph Database Configuration ---
 # This section configures the connection to your Neo4j database instance.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,17 @@ Copy the template and fill in your credentials.
 ```bash
 cp .env.example .env
 ```
-Open the new .env file and add your GOOGLE_API_KEY and the NEO4J_PASSWORD you just created.
+Open the new .env file and add your `GOOGLE_API_KEY` and the `NEO4J_PASSWORD` you just created.
+
+The `.env.example` file lists all configurable variables. Key ones include:
+*   `GOOGLE_API_KEY`: Your Google API key for Gemini.
+*   `LLM_MODEL`: The specific Gemini model to use (e.g., "gemini-1.5-flash-latest").
+*   `NEO4J_URI`: Connection URI for your Neo4j instance.
+*   `NEO4J_USERNAME`: Username for Neo4j.
+*   `NEO4J_PASSWORD`: Password for Neo4j.
+*   `ENTREZ_EMAIL` & `ENTREZ_API_KEY`: For PubMed search tool.
+*   `MAX_CONCURRENT_GEMINI_CALLS`: (Optional) The maximum number of concurrent calls to the Gemini API during data ingestion. Defaults to 5. This helps manage API rate limits and system load.
+
 Stage 2: Knowledge Base Construction
 This is the core offline process where you build the AI's brain.
 Step 2.1: Populate the Foundational Repository (One-Time Task)


### PR DESCRIPTION
…ontrol

This commit refactors `ingest.py` and `ingest_old.py` to use asynchronous operations (async/await) for calls to the Gemini API (ChatGoogleGenerativeAI).

Key changes include:

-   **Asynchronous API Calls:** Functions making calls to the LLM (`semantic_chunker`, `extract_entities_from_chunk`) have been converted to `async def` and now use `chain.ainvoke`.
-   **Concurrency Limiting:** An `asyncio.Semaphore` is used in both scripts to limit the maximum number of concurrent calls to the Gemini API. This limit is configurable via the `MAX_CONCURRENT_GEMINI_CALLS` environment variable (defaulting to 5).
-   **Concurrent File Processing:** The `main` functions in both scripts now use `asyncio.gather` to process multiple input documents concurrently.
-   **Semaphore Propagation:** The semaphore is initialized in `main` and passed down to the functions that make LLM calls, ensuring a global concurrency limit is respected across all asynchronous operations.
-   **Documentation:** The new `MAX_CONCURRENT_GEMINI_CALLS` environment variable has been documented in `README.md` and added to `.env.example`.

These changes aim to improve the performance and robustness of the data ingestion process by preventing API rate limiting issues and making better use of resources when handling multiple files or large documents.