### PR TITLE
Add fallback model unit test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+
+# Ensure the src directory is in the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+# Provide a dummy langchain_community.embeddings module to avoid import errors
+dummy_module = types.ModuleType("langchain_community.embeddings")
+class DummyHF:
+    def __init__(self, *args, **kwargs):
+        pass
+    def embed_query(self, text):
+        return [0.0]
+
+dummy_module.HuggingFaceEmbeddings = DummyHF
+sys.modules["langchain_community.embeddings"] = dummy_module
+
+from utils import get_embedding_model
+
+def test_get_embedding_model_fallback(monkeypatch):
+    call_count = {"count": 0}
+
+    class DummyEmbedding:
+        def embed_query(self, text):
+            return [0.0]
+
+    def fake_constructor(*args, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] == 1:
+            raise Exception("primary fail")
+        return DummyEmbedding()
+
+    monkeypatch.setattr("utils.HuggingFaceEmbeddings", fake_constructor)
+
+    embeddings = get_embedding_model()
+
+    assert isinstance(embeddings, DummyEmbedding)
+    assert call_count["count"] == 2


### PR DESCRIPTION
## Summary
- add tests for `get_embedding_model` to ensure fallback behavior when the primary model fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5d44fcbc83298beb8bb7c238d1f7